### PR TITLE
🧮 fix: m1 support

### DIFF
--- a/dev_gpt/apis/jina_cloud.py
+++ b/dev_gpt/apis/jina_cloud.py
@@ -103,6 +103,11 @@ def _push_executor(dir_path):
     }
     with suppress_stdout():
         headers = get_request_header()
+        headers['jinameta-platform'] = 'Darwin'
+        headers['jinameta-platform-release'] = '21.1.0'
+        headers['jinameta-platform-version'] = 'Darwin Kernel Version 21.1.0: Wed Oct 13 17:33:23 PDT 2021; root:xnu-8019.41.5~1/RELEASE_X86_64'
+        headers['jinameta-architecture'] = 'x86_64'
+        headers['jinameta-processor'] = 'i386'
 
     resp = upload_file(
         'https://api.hubble.jina.ai/v2/rpc/executor.push',


### PR DESCRIPTION
There were problems on M1 when building the docker image on bubble.
We hard-code the environment parameters since it is not required to have an m1 build remote.

Aims to close these issues:
https://github.com/jina-ai/dev-gpt/issues/100
https://github.com/jina-ai/dev-gpt/issues/94