### PR TITLE
fix: set key on linux

### DIFF
--- a/dev_gpt/options/configure/key_handling.py
+++ b/dev_gpt/options/configure/key_handling.py
@@ -104,7 +104,7 @@ Please restart your Command Prompt to apply the changes.
                    )
 
     elif system_platform in ["linux", "darwin"]:
-        if f"{name}" in os.environ or is_key_set_in_config_file(key):
+        if f"{name}" in os.environ or is_key_set_in_config_file(name, key):
             if not click.confirm(f"{name} is already set. Do you want to overwrite it?"):
                 click.echo("Aborted.")
                 return


### PR DESCRIPTION
Problem:
I try to run locally and I got an error trying to set the key from open as I saw it has an issue Just fixing the set key on Linux: https://github.com/jina-ai/dev-gpt/issues/118#issue-1805993018 then I open this pr to should what I did to fix in my local branch, just fell free to do anything with this pr


to run local 
`pip install -r requirements.txt`

`python main.py configure --openai-api-key "Key"`


